### PR TITLE
Adds simple support for Flash Forge's .gx gcode files.

### DIFF
--- a/js/gCodeReader.js
+++ b/js/gCodeReader.js
@@ -176,6 +176,8 @@ GCODE.gCodeReader = (function(){
         }else if(gcode.match(/Miracle/)){
             slicer = 'makerbot';
             getParamsFromMiracleGrue(gcode);
+        }else if(gcode.match(/ffslicer/)){
+            slicer = 'Flash Forge'
         }
 
     }

--- a/js/ui.js
+++ b/js/ui.js
@@ -181,7 +181,7 @@ GCODE.ui = (function(){
 
         var output = [];
         for (var i = 0, f; f = files[i]; i++) {
-            if(f.name.toLowerCase().match(/^.*\.(?:gcode|g|txt|gco)$/)){
+            if(f.name.toLowerCase().match(/^.*\.(?:gcode|g|txt|gco|gx)$/)){
                 output.push('<li>File extensions suggests GCODE</li>');
             }else{
                 output.push('<li><strong>You should only upload *.gcode files! I will not work with this one!</strong></li>');


### PR DESCRIPTION
Adds support for the .gx files created by FlashForge's slicer. The file itself is a normal gcode file with some binary header information, and normally loaded just fine if the .gx filetype was changes to a .gcode filetype. Simply allowing it to be selected in the load file is enough to make it work for Flashforge users.

Implements changes requested in issue #50. 