### PR TITLE
Ability to load GCODE file at startyp of gCodeViewer.

### DIFF
--- a/js/ui.js
+++ b/js/ui.js
@@ -412,6 +412,25 @@ GCODE.ui = (function(){
                 $('#errAnalyseTab').removeClass('hide');
             }
 
+			var InFilemame = new RegExp('[\?&]filename=([^&#]*)').exec(window.location.href);
+			var ValidFilename = !/[^a-z0-9_.@()-]/i.test(InFilemame[1]);
+			if(ValidFilename === false) InFilemame = null;
+			if(InFilemame !== null){
+				var LocalGCODE = $.get( "gcode\\" + InFilemame[1], "", null, "text")
+				.done(function() {
+					var theFile = [];
+					chooseAccordion('progressAccordionTab');
+					setProgress('loadProgress', 0);
+					setProgress('analyzeProgress', 0);
+					theFile.target = [];
+					theFile.target.result = LocalGCODE.responseText;
+					LocalGCODE.responseText = null;
+					GCODE.gCodeReader.loadFile(theFile);
+				})
+				.fail(function() {
+					alert( "Error loading GCODE file!" );					
+				});
+			}
         },
 
         processOptions: function(){


### PR DESCRIPTION
Add HTTP GET parameters "filename" that allow user tu specify a GCODE file that will be loaded automatically to gCodeViewer at startup.

The file have to be placed in "gcode" subdirectory.
Any attempt to escape from "gcode" subdirectory are blocked.
This is useful when you want to start gCodeViewer from other application.
Work well in Firefox. 
Edge is tragically slow.

Example of use:
  firefox.exe file:///C:/gCodeViewer/index.html?filename=test.gcode
