### PR TITLE
Implement volumetric E

### DIFF
--- a/index.html
+++ b/index.html
@@ -227,6 +227,7 @@
                             <label for="plasticABS"><input type="radio" name="radPlastic" id="plasticABS" value="ABS"  onclick="GCODE.ui.processOptions()" checked>ABS</label>
                             <label for="plasticPLA"><input type="radio" name="radPlastic" id="plasticPLA" value="PLA"  onclick="GCODE.ui.processOptions()" >PLA</label>
                         <label for="nozzleDia">Nozzle size: <input type="text" value="0.4" id="nozzleDia" onchange="GCODE.ui.processOptions()"/></label>
+						<label for="volumetricE"><input type="checkbox" id="volumetricE" onclick="GCODE.ui.processOptions()"> Volumetric E</label>
                         <label for="hourlyCost">Printer hourly cost: <input type="text" value="1.00" id="hourlyCost" onchange="GCODE.ui.processOptions()"/></label>
                         <label for="filamentPrice">Filament price(per gram): <input type="text" value="0.05" id="filamentPrice" onchange="GCODE.ui.processOptions()"/></label>
                     </div>

--- a/js/ui.js
+++ b/js/ui.js
@@ -415,61 +415,39 @@ GCODE.ui = (function(){
         },
 
         processOptions: function(){
-            if(document.getElementById('sortLayersCheckbox').checked)GCODE.gCodeReader.setOption({sortLayers: true});
-            else GCODE.gCodeReader.setOption({sortLayers: false});
+			GCODE.gCodeReader.setOption({
+				sortLayers: document.getElementById('sortLayersCheckbox').checked,
+				purgeEmptyLayers: document.getElementById('purgeEmptyLayersCheckbox').checked,
 
-            if(document.getElementById('purgeEmptyLayersCheckbox').checked)GCODE.gCodeReader.setOption({purgeEmptyLayers: true});
-            else GCODE.gCodeReader.setOption({purgeEmptyLayers: false});
+				filamentDia: Number($('#filamentDia').val()) || 1.75,
+				nozzleDia: Number($('#nozzleDia').val()) || 0.4,
+				hourlyCost: Number($('#hourlyCost').val()) || 1.0,
+				filamentPrice: Number($('#filamentPrice').val()) || 0.05,
+
+				filamentType: document.getElementById('plasticABS').checked ? 'ABS' : 'PLA',
+			});
+
+			GCODE.renderer.setOption({
+				moveModel: document.getElementById('moveModelCheckbox').checked,
+				showMoves: document.getElementById('showMovesCheckbox').checked,
+				showRetracts: document.getElementById('showRetractsCheckbox').checked,
+				differentiateColors: document.getElementById('differentiateColorsCheckbox').checked,
+				actualWidth: document.getElementById('thickExtrusionCheckbox').checked,
+				alpha: document.getElementById('alphaCheckbox').checked,
+				showNextLayer: document.getElementById('showNextLayer').checked,
+			});
 
             showGCode = document.getElementById('showGCodeCheckbox').checked;
 
-            if(document.getElementById('moveModelCheckbox').checked)GCODE.renderer.setOption({moveModel: true});
-            else GCODE.renderer.setOption({moveModel: false});
-
-            if(document.getElementById('showMovesCheckbox').checked)GCODE.renderer.setOption({showMoves: true});
-            else GCODE.renderer.setOption({showMoves: false});
-
-            if(document.getElementById('showRetractsCheckbox').checked)GCODE.renderer.setOption({showRetracts: true});
-            else GCODE.renderer.setOption({showRetracts: false});
-
-            if(document.getElementById('differentiateColorsCheckbox').checked)GCODE.renderer.setOption({differentiateColors: true});
-            else GCODE.renderer.setOption({differentiateColors: false});
-
-            if(document.getElementById('thickExtrusionCheckbox').checked)GCODE.renderer.setOption({actualWidth: true});
-            else GCODE.renderer.setOption({actualWidth: false});
-
-            if(document.getElementById('alphaCheckbox').checked)GCODE.renderer.setOption({alpha: true});
-            else GCODE.renderer.setOption({alpha: false});
-
-            if(document.getElementById('showNextLayer').checked)GCODE.renderer.setOption({showNextLayer: true});
-            else GCODE.renderer.setOption({showNextLayer: false});
-
             if(document.getElementById('renderErrors').checked){
-                GCODE.renderer.setOption({showMoves: false});
-                GCODE.renderer.setOption({showRetracts: false});
-                GCODE.renderer.setOption({renderAnalysis: true});
-                GCODE.renderer.setOption({actualWidth: true});
+                GCODE.renderer.setOption({
+					showMoves: false,
+					showRetracts: false,
+					renderAnalysis: true,
+					actualWidth: true,
+				});
             }
             else GCODE.renderer.setOption({renderAnalysis: false});
-
-            var filamentDia = 1.75;
-            if(Number($('#filamentDia').attr('value'))) {filamentDia = Number($('#filamentDia').attr('value'));}
-            GCODE.gCodeReader.setOption({filamentDia: filamentDia});
-
-            var nozzleDia = 0.4;
-            if(Number($('#nozzleDia').attr('value'))) {nozzleDia = Number($('#nozzleDia').attr('value'));}
-            GCODE.gCodeReader.setOption({nozzleDia: nozzleDia});
-
-            var hourlyCost = 1.0;
-            if(Number($('#hourlyCost').attr('value'))) {hourlyCost = Number($('#hourlyCost').attr('value'));}
-            GCODE.gCodeReader.setOption({hourlyCost: hourlyCost});
-
-            var filamentPrice = 0.05;
-            if(Number($('#filamentPrice').attr('value'))) {filamentPrice = Number($('#filamentPrice').attr('value'));}
-            GCODE.gCodeReader.setOption({filamentPrice: filamentPrice});
-
-            if(document.getElementById('plasticABS').checked)GCODE.gCodeReader.setOption({filamentType: "ABS"});
-            if(document.getElementById('plasticPLA').checked)GCODE.gCodeReader.setOption({filamentType: "PLA"});
 
             if(document.getElementById('speedDisplayRadio').checked)GCODE.renderer.setOption({speedDisplayType: displayType.speed});
             if(document.getElementById('exPerMMRadio').checked)GCODE.renderer.setOption({speedDisplayType: displayType.expermm});


### PR DESCRIPTION
Some firmwares allow for using volumetric E, so that the unit for E in G0/G1 moves is given in mm³ instead of mm. The rationale is to allow changing the filament diameter without having to reslice the model. My commit adds a checkbox under printer settings to correctly compensate for that.